### PR TITLE
cdi_generator: raise csv field limit; emit keywords in CatalogDetails

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ export BACKEND_CONFIG_FILE=../conf/backend_config.json
 Globus requires additional frontend plugin, OAuth secret, Dataverse setting,
 and storage configuration. See [GLOBUS_INTEGRATION.md](GLOBUS_INTEGRATION.md#configuration).
 
-**Dataverse File System Drivers**
+#### Dataverse File System Drivers
 
 The application can directly upload files to the Dataverse file system. Two drivers are supported:
 

--- a/ddi-cdi.md
+++ b/ddi-cdi.md
@@ -383,12 +383,14 @@ When generation completes (either by waiting or returning later):
 
 After generation, you have two options:
 
-**Option A: Download**
+##### Option A: Download
+
 - Click the **"Download"** button to save the JSON-LD file locally
 - File is named `ddi-cdi-[timestamp].jsonld`
 - Useful for archiving or sharing outside of Dataverse
 
-**Option B: Open in Viewer (Recommended)**
+##### Option B: Open in Viewer (Recommended)
+
 - Click the **"Open in Viewer"** button to open the **cdi-viewer** in a new browser window
 - The system first adds your DDI-CDI file to the dataset with the correct MIME type
 - The viewer opens and loads the file directly from Dataverse

--- a/image/cdi_generator_jsonld.py
+++ b/image/cdi_generator_jsonld.py
@@ -69,6 +69,11 @@ import chardet
 from datasketch import HyperLogLog
 from dateutil import parser as dateparser
 
+# Real deposited CSVs carry free-text fields (open survey answers, JSON blobs)
+# far beyond the csv module's 128 KiB default field limit; profiling must not
+# die on them.
+csv.field_size_limit(min(sys.maxsize, 2**31 - 1))
+
 
 # ---- Official DDI-CDI 1.0 JSON-LD Context URL ----
 DDI_CDI_CONTEXT = "https://ddi-cdi.github.io/m2t-ng/DDI-CDI_1-0/encoding/json-ld/ddi-cdi.jsonld"
@@ -1154,11 +1159,14 @@ def _build_catalog_details(
         if related:
             catalog["relatedResource"] = related
     
-    # Type of resource (subjects/keywords as ControlledVocabularyEntry)
-    if rich_metadata.get("subjects"):
+    # Type of resource (subjects/keywords as ControlledVocabularyEntry).
+    # CatalogDetails has no dedicated keyword property in DDI-CDI 1.0, so
+    # keywords ride with the subjects here rather than being dropped.
+    topics = list(rich_metadata.get("subjects", [])) + list(rich_metadata.get("keywords", []))
+    if topics:
         catalog["typeOfResource"] = {
             "@type": "ControlledVocabularyEntry",
-            "entryValue": "; ".join(rich_metadata["subjects"]),
+            "entryValue": "; ".join(topics),
         }
     
     return catalog

--- a/image/test_cdi_generator_jsonld.py
+++ b/image/test_cdi_generator_jsonld.py
@@ -172,6 +172,20 @@ class TestCSVProcessing(unittest.TestCase):
         self.assertEqual(stats[1].xsd_datatype_name(), "string")   # name
         self.assertEqual(stats[2].xsd_datatype_name(), "integer")  # age
 
+    def test_csv_with_oversized_field(self):
+        """A free-text field beyond the csv module's 128 KiB default limit
+        must profile, not crash (real deposited data carries such fields)."""
+        csv_file = self.test_path / "bigfield.csv"
+        big = "x" * (256 * 1024)
+        csv_file.write_text(f"id,text\n1,{big}\n2,small\n")
+
+        cols, stats, info, _, _ = cdi_gen.stream_profile_csv(
+            csv_file, header=True, compute_md5=False
+        )
+
+        self.assertEqual(cols, ["id", "text"])
+        self.assertEqual(info["rows_read"], 2)
+
     def test_csv_with_missing_values(self):
         """Test CSV with missing/null values"""
         csv_file = self.test_path / "missing.csv"
@@ -312,6 +326,29 @@ class TestMetadataExtraction(unittest.TestCase):
 
         description = cdi_gen.extract_dataset_description(metadata)
         self.assertEqual(description, "A test description")
+
+    def test_catalog_details_emits_keywords(self):
+        """Keywords extracted from the citation block must reach the
+        CatalogDetails node (folded into typeOfResource with the subjects,
+        since DDI-CDI 1.0 CatalogDetails has no keyword property)."""
+        catalog = cdi_gen._build_catalog_details(
+            {
+                "title": "Test Dataset",
+                "subjects": ["Social Sciences"],
+                "keywords": ["elections", "turnout"],
+            }
+        )
+        entry = catalog["typeOfResource"]["entryValue"]
+        self.assertIn("Social Sciences", entry)
+        self.assertIn("elections", entry)
+        self.assertIn("turnout", entry)
+
+    def test_catalog_details_keywords_only(self):
+        """typeOfResource must be emitted even when only keywords exist."""
+        catalog = cdi_gen._build_catalog_details(
+            {"title": "Test Dataset", "keywords": ["elections"]}
+        )
+        self.assertEqual(catalog["typeOfResource"]["entryValue"], "elections")
 
 
 class TestDDIMetadata(unittest.TestCase):


### PR DESCRIPTION
<!-- @ai-generated: true -->

# @ai-tool: Claude Code (Fable 5)

## Summary

- Two small fixes to image/cdi_generator_jsonld.py, surfaced by running the generator over real Dataverse replication datasets at scale.
- Fix 1: raise csv.field_size_limit. Deposited CSVs carry free-text fields (open survey answers, JSON blobs) beyond the csv module's 128 KiB default, which makes stream_profile_csv fail hard with "field larger than field limit (131072)" (hit on a real Harvard Dataverse dataset, doi:10.7910/DVN/3TZAEB). The limit is now raised at module import so profiling survives such files.
- Fix 2: emit keywords in CatalogDetails. extract_rich_metadata already extracts the citation block's keyword values, but _build_catalog_details never used them, so they were silently dropped from the JSON-LD output. DDI-CDI 1.0 CatalogDetails has no dedicated keyword property (checked against the official context), so keywords are folded into typeOfResource together with the subjects, the placement the existing code comment already intended. In a 25-dataset sample of political-science replication data, 11 datasets carried keywords that were being lost.
- Three regression tests added (oversized field profiles without error; keywords reach typeOfResource, with and without subjects). Full suite: 43 tests pass (4 xconvert tests skip without the binary). No new JSON-LD terms, no context change; datasets without keywords produce byte-identical output.
- Also fixes the pre-existing markdownlint MD036 failures (bold text used as headings in ddi-cdi.md and README.md) that turned the governance check red for every PR; three lines, second commit.

## AI Provenance (required for AI-assisted changes)

- Prompt: "implement the ddi-cdi generator" per the brief platform/ddi_cdi_generator_prompt.md in ErykKul/rag, then "push 2 and 3" (the two bugfixes) upstream to libis/rdm-integration
- Model: Claude Fable 5 (claude-fable-5), Claude Code
- Date: 2026-07-03T12:43:17Z
- Author: @ErykKul
- Role: deployer

## Compliance checklist

- [x] No secrets/PII
- [ ] Transparency notice updated (if user-facing) - N/A, not user-facing
- [x] Agent logging enabled (actions/decisions logged)
- [x] Kill-switch / feature flag present for AI features - N/A, this change introduces no AI feature
- [x] No prohibited practices under EU AI Act
- [x] Human oversight retained (required if high-risk or agent mode)
- Risk classification: limited
- Personal data: no
- DPIA: N/A
- Automated decision-making: no
- Agent mode used: yes
- Vendor GPAI compliance reviewed: N/A
- [x] License/IP attestation
- Attribution: N/A

## Tests & Risk

- [x] Unit/integration tests added/updated
- [x] Security scan passed
- Rollback plan: revert the single commit; the change is additive and touches only the CSV profiler limit and one CatalogDetails field
- [ ] Docs updated (if needed) - N/A, behavior documented in code comments and tests
